### PR TITLE
Revert "use LidoError for quote_withdraw_stake"

### DIFF
--- a/core/src/typedefs/exchange_rate.rs
+++ b/core/src/typedefs/exchange_rate.rs
@@ -1,8 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use sanctum_u64_ratio::{Floor, Ratio};
 
-use crate::LidoError;
-
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, BorshDeserialize, BorshSerialize)]
 pub struct ExchangeRate {
     pub computed_in_epoch: u64,
@@ -16,15 +14,12 @@ impl ExchangeRate {
     ///
     /// Returns None on arithmetic failure
     #[inline]
-    pub const fn quote_withdraw_stake(&self, stsol_amount: u64) -> Result<u64, LidoError> {
+    pub const fn quote_withdraw_stake(&self, stsol_amount: u64) -> Option<u64> {
         let ratio = self.sol_balance_over_st_sol_supply();
         if ratio.0.is_zero() {
-            return Err(LidoError::CalculationFailure);
+            return None;
         }
-        match ratio.apply(stsol_amount) {
-            Some(v) => Ok(v),
-            None => Err(LidoError::CalculationFailure),
-        }
+        ratio.apply(stsol_amount)
     }
 
     #[inline]


### PR DESCRIPTION
Since theres only one failure case, we might as well stick with `Option` instead. Also for consistency across the APIs